### PR TITLE
🤖 Auto-translate: Update All Locale Localizations

### DIFF
--- a/generated/ar-sa/global.yaml
+++ b/generated/ar-sa/global.yaml
@@ -1,0 +1,13 @@
+components:
+  services:
+    rubric:
+      template:
+        criteria: "معيار {idx_LOCALIZED}"
+        column1: "ممتاز"
+        column2: "مقبول"
+        column3: "غير مُرضٍ"
+        column4: "فقير"
+      newCriteriaHeading: "معيار جديد"
+      newColumnHeading: "مستوى جديد"
+      newCopyTitle: "{rubricTitle} {date} نسخة"
+      persistError: "حدث خطأ أثناء حفظ نموذج التقييم. الرجاء تحديث الصفحة والمحاولة مرة أخرى لاحقاً."

--- a/generated/es-es/global.yaml
+++ b/generated/es-es/global.yaml
@@ -1,0 +1,13 @@
+components:
+  services:
+    rubric:
+      template:
+        criteria: "Criterio {idx_LOCALIZED}"
+        column1: "Excelente"
+        column2: "Satisfactorio"
+        column3: "Insatisfactorio"
+        column4: "Pobre"
+      newCriteriaHeading: "Nuevo Criterio"
+      newColumnHeading: "Nuevo Nivel"
+      newCopyTitle: "{rubricTitle} {date} copia"
+      persistError: "Se produjo un error al guardar la rúbrica. Por favor, actualice la página e inténtelo de nuevo más tarde."

--- a/generated/fr-fr/global.yaml
+++ b/generated/fr-fr/global.yaml
@@ -1,0 +1,13 @@
+components:
+  services:
+    rubric:
+      template:
+        criteria: "Critère {idx_LOCALIZED}"
+        column1: "Excellent"
+        column2: "Satisfaisant"
+        column3: "Insatisfaisant"
+        column4: "Pauvre"
+      newCriteriaHeading: "Nouveau Critère"
+      newColumnHeading: "Nouveau niveau"
+      newCopyTitle: "{rubricTitle} {date} copie"
+      persistError: "Une erreur est survenue lors de l'enregistrement {the rubric}. Veuillez rafraîchir la page et réessayer plus tard."

--- a/generated/jp-jp/global.yaml
+++ b/generated/jp-jp/global.yaml
@@ -1,0 +1,13 @@
+components:
+  services:
+    rubric:
+      template:
+        criteria: "基準 {idx_LOCALIZED}"
+        column1: "素晴らしい"
+        column2: "良好"
+        column3: "不満足"
+        column4: "貧しい"
+      newCriteriaHeading: "ニュー・クリテリオン"
+      newColumnHeading: "新レベル"
+      newCopyTitle: "{rubricTitle}{date} コピー"
+      persistError: "ルーブリックの保存中にエラーが発生しました。ページを更新し、時間を置いてからもう一度お試しください。"

--- a/generated/ko-kr/global.yaml
+++ b/generated/ko-kr/global.yaml
@@ -1,0 +1,13 @@
+components:
+  services:
+    rubric:
+      template:
+        criteria: "기준 {idx_LOCALIZED}"
+        column1: "훌륭합니다"
+        column2: "만족스러운"
+        column3: "미흡한"
+        column4: "가난한"
+      newCriteriaHeading: "신 기준"
+      newColumnHeading: "새로운 레벨"
+      newCopyTitle: "{rubricTitle} {date} 사본"
+      persistError: "루브릭 저장 중 오류가 발생했습니다. 페이지를 새로고침하고 나중에 다시 시도해 주세요."


### PR DESCRIPTION
This Pull Request automatically updates `generated/<locale>/global.yaml` files with translations
based on **only the changed strings** detected in `src/global.yaml`.

Locales updated: es-es, fr-fr, jp-jp, ko-kr, ar-sa
Triggered by commit: 957e40267e26be3f056f94b040ebf2389b908272
By: @johnson-abraham

Please review and merge if translations are correct.